### PR TITLE
Enhanced venv creation

### DIFF
--- a/dependencies/core.py
+++ b/dependencies/core.py
@@ -686,9 +686,18 @@ def get_python_modules(venv_path):
     return packages
 
 
-def calculate_hash(file_url):
-    checksum = hashlib.md5()
-    with open(file_url, "rb") as f:
+def calculate_hash(filepath):
+    """Calculate sha256 hash of file.
+
+    Args:
+        filepath (str): Path to a file.
+
+    Returns:
+        str: File sha256 hashs.
+    """
+
+    checksum = hashlib.sha256()
+    with open(filepath, "rb") as f:
         for chunk in iter(lambda: f.read(8192), b""):
             checksum.update(chunk)
     return checksum.hexdigest()
@@ -720,7 +729,7 @@ def prepare_package_data(venv_zip_path, bundle):
         "source_addons": bundle.addons,
         "installer_version": bundle.installer_version,
         "checksum": checksum,
-        "checksum_algorithm": "md5",
+        "checksum_algorithm": "sha256",
         "file_size": os.stat(venv_zip_path).st_size,
         "platform_name": platform_name,
     }

--- a/dependencies/core.py
+++ b/dependencies/core.py
@@ -444,6 +444,15 @@ def get_full_toml(base_toml_data, addon_tomls):
         base_toml_data = merge_tomls(
             base_toml_data, addon_toml_data, addon_name)
 
+    # Convert all 'ConstraintClassesHint' to 'str'
+    main_poetry_tool = base_toml_data["tool"]["poetry"]
+    main_dependencies = main_poetry_tool["dependencies"]
+    modified_dependencies = {}
+    for key, value in main_dependencies.items():
+        if not isinstance(value, (str, dict)):
+            modified_dependencies[key] = str(value)
+    main_dependencies.update(modified_dependencies)
+
     return base_toml_data
 
 

--- a/dependencies/core.py
+++ b/dependencies/core.py
@@ -187,8 +187,12 @@ def get_bundle_addons_tomls(con, bundle):
 
 
 def find_installer_by_name(con, bundle_name, installer_name):
+    platform_name = platform.system().lower()
     for installer in con.get_installers()["installers"]:
-        if installer["version"] == installer_name:
+        if (
+            installer["platform"] == platform_name
+            and installer["version"] == installer_name
+        ):
             return installer
     raise ValueError(f"{bundle_name} must have installer present.")
 

--- a/dependencies/core.py
+++ b/dependencies/core.py
@@ -516,8 +516,8 @@ def prepare_new_venv(full_toml_data, output_root, python_version):
 
     _convert_url_constraints(full_toml_data)
 
-    with open(toml_path, "w") as fp:
-        fp.write(toml.dumps(full_toml_data))
+    with open(toml_path, "w") as stream:
+        toml.dump(full_toml_data, stream)
 
     poetry_bin = os.path.join(poetry_home, "bin", "poetry")
     venv_path = os.path.join(output_root, ".venv")

--- a/dependencies/core.py
+++ b/dependencies/core.py
@@ -80,7 +80,9 @@ def get_pyenv_arguments(output_root, python_version):
     if not pyenv_path:
         return
     print(f"Installing Python {python_version} with pyenv")
-    result = subprocess.run([pyenv_path, "install", python_version])
+    result = subprocess.run(
+        [pyenv_path, "install", python_version, "--quiet", "--skip-existing"]
+    )
     if result.returncode != 0:
         raise RuntimeError(f"Failed to install python {python_version}")
     subprocess.run(

--- a/dependencies/core.py
+++ b/dependencies/core.py
@@ -217,11 +217,13 @@ def get_installer_toml(installer):
         dict[str, Any]: Installer toml content.
     """
 
+    python_modules = copy.deepcopy(installer["pythonModules"])
+    python_modules["python"] = installer["pythonVersion"]
     return {
         "tool": {
             "poetry": {
                 # Create copy to avoid modifying original data
-                "dependencies": copy.deepcopy(installer["pythonModules"]),
+                "dependencies": python_modules,
 
                 # These data have no effect, but are required by poetry
                 "name": "AYONDepPackage",

--- a/dependencies/core.py
+++ b/dependencies/core.py
@@ -80,9 +80,10 @@ def get_pyenv_arguments(output_root, python_version):
     if not pyenv_path:
         return
     print(f"Installing Python {python_version} with pyenv")
-    result = subprocess.run(
-        [pyenv_path, "install", python_version, "--quiet", "--skip-existing"]
-    )
+    install_args = [pyenv_path, "install", python_version, "--skip-existing"]
+    if platform.system().lower() == "windows":
+        install_args.append("--quiet")
+    result = subprocess.run(install_args)
     if result.returncode != 0:
         raise RuntimeError(f"Failed to install python {python_version}")
     subprocess.run(

--- a/dependencies/core.py
+++ b/dependencies/core.py
@@ -485,13 +485,13 @@ def zip_venv(venv_folder, zip_filepath):
                 if root_name == "__pycache__":
                     continue
 
-                dst_root = ""
+                dst_root = "dependencies"
                 if len(root) > sp_root_len_start:
-                    dst_root = root[sp_root_len_start:]
+                    dst_root = os.path.join(dst_root, root[sp_root_len_start:])
 
                 for filename in filenames:
                     src_path = os.path.join(root, filename)
-                    dst_path = os.path.join("dependencies", dst_root, filename)
+                    dst_path = os.path.join(dst_root, filename)
                     zipf.write(src_path, dst_path)
 
 


### PR DESCRIPTION
## Description
List of changes:
- create new poetry for each call of 'create_package' (do not use poetry from dependencies tool)
- add support for pyenv - install same version as installer have (this is now optional)
- fixed lookup for installer - check platform too
- tempdir should be always deleted
- use `sha256` instead of `md5` for checksum
- change how version compatibility check works

Version compatibility check also validates python version. At this moment have one big missing piece which is handling non-version sources.