### PR TITLE
Prepare functionality for newer ayon api

### DIFF
--- a/dependencies/core.py
+++ b/dependencies/core.py
@@ -704,7 +704,7 @@ def get_applicable_package(con, new_toml):
         new_toml (dict[str, Any]): Data of regular pyproject.toml file.
 
     Returns:
-        str: name of matching package
+        dict[str, Any]: Data of matching package.
     """
 
     toml_python_packages = dict(


### PR DESCRIPTION
## Description
Prepare functionality that `upload_dependency_package` in ayon api does not expect `platform_name`. The argument is deprecated since 0.3.0 of ayon server backend and will be removed in future releases of ayon api.

### Additional changes
Changed functions to expect platform name in arguments instead of getting it on own in each individually.