### PR TITLE
Runtime dependencies from addons

### DIFF
--- a/dependencies/_runtime_deps.py
+++ b/dependencies/_runtime_deps.py
@@ -1,0 +1,53 @@
+"""Get runtime python modules from build using this script.
+
+Execute this script using venv python executable to get runtime python modules.
+The script is using 'pkg_resources' to get runtime modules and their versions.
+Output is stored to a json file that must be provided by last argument.
+"""
+
+import sys
+import json
+from pathlib import Path
+
+
+def get_runtime_modules(runtime_root):
+    sys.path.insert(0, runtime_root)
+    # Import 'pkg_resources' after adding runtime root to 'sys.path'
+    import pkg_resources
+
+    runtime_root = Path(runtime_root)
+
+    # One of the dependencies from runtime dependencies must be imported
+    #   so 'pkg_resources' have them available in 'working_set'
+    # This approach makes sure that we use right version that are really
+    #   installed in runtime dependencies directory. Keep in mind that some
+    #   dependencies have other modules as requirements that may not be
+    #   listed in pyproject.toml and there might not be explicit version.
+    #   Also using version from modules require to import them and be lucky
+    #   that version is available and that installed module have same name
+    #   as pip package (e.g. 'PIL' vs. 'Pillow').
+    # TODO find a better way how to define one dependency to import
+    # Randomly chosen module inside runtime dependencies
+
+    output = {}
+    for package in pkg_resources.working_set:
+        package_path = Path(package.module_path)
+        if package_path.is_relative_to(runtime_root):
+            output[package.project_name] = package.version
+    return output
+
+
+def main():
+    output_path = sys.argv[-1]
+    with open(output_path, "r") as stream:
+        data = json.load(stream)
+
+    data["runtime_dependencies"] = get_runtime_modules(data["runtime_root"])
+
+    print(f"Storing output to {output_path}")
+    with open(output_path, "w") as stream:
+        json.dump(data, stream, indent=4)
+
+
+if __name__ == "__main__":
+    main()

--- a/dependencies/core.py
+++ b/dependencies/core.py
@@ -462,7 +462,7 @@ def get_full_toml(base_toml_data, addon_tomls, platform_name):
         # TODO handler other version-less contraints
         if link.scheme.startswith("git+"):
             url = ParsedUrl.parse(link.url)
-            new_value = {"git": url.url,}
+            new_value = {"git": url.url}
             if url.rev:
                 new_value["rev"] = url.rev
 

--- a/dependencies/core.py
+++ b/dependencies/core.py
@@ -888,6 +888,8 @@ def prepare_package_data(
 
     venv_path = os.path.join(os.path.dirname(venv_zip_path), ".venv")
     python_modules = get_python_modules(venv_path)
+    # Runtime dependencies do not have special key
+    python_modules.update(runtime_dependencies)
 
     package_name = os.path.basename(venv_zip_path)
     checksum = calculate_hash(venv_zip_path)
@@ -895,7 +897,6 @@ def prepare_package_data(
     return {
         "filename": package_name,
         "python_modules": python_modules,
-        "runtime_python_modules": runtime_dependencies,
         "source_addons": bundle.addons,
         "installer_version": bundle.installer_version,
         "checksum": checksum,

--- a/dependencies/core.py
+++ b/dependencies/core.py
@@ -9,6 +9,7 @@ import json
 import subprocess
 import collections
 import shutil
+import itertools
 from typing import Dict, Union
 from packaging import version
 from dataclasses import dataclass
@@ -332,29 +333,36 @@ def merge_tomls(main_toml, addon_toml, addon_name, platform_name):
 
     main_poetry = main_toml["ayon"]["runtimeDependencies"]
     for dependency, dep_info in addon_poetry.items():
-        if main_poetry.get(dependency):
-            if dep_info.get(platform_name):
-                dep_version = dep_info[platform_name]["version"]
-                main_version = (
-                    main_poetry[dependency][platform_name]["version"])
-            else:
-                dep_version = dep_info["version"]
-                main_version = main_poetry[dependency]["version"]
+        if isinstance(dep_info, dict):
+            if platform_name in dep_info:
+                dep_info = dep_info[platform_name]
 
-            resolved_vers = _get_correct_version(main_version, dep_version)
-            if not isinstance(resolved_vers, ConstraintClasses):
-                raise ValueError(
-                    "RuntimeDependency must be defined as version.")
-            if (
-                not resolved_vers.is_empty()
-                and parse_constraint(dep_version).allows(resolved_vers)
-            ):
-                dep_info = main_poetry[dependency]
-            else:
-                raise ValueError(
-                    f"Cannot result {dependency} with"
-                    f" {dep_info} for {addon_name}"
-                )
+            if "version" in dep_info:
+                dep_info = dep_info["version"]
+
+        if dependency not in main_poetry:
+            main_poetry[dependency] = dep_info
+            continue
+
+        main_dep_info = main_poetry[dependency]
+        if isinstance(main_dep_info, dict):
+            if platform_name in main_dep_info:
+                main_dep_info = main_dep_info[platform_name]
+
+        resolved_vers = _get_correct_version(main_dep_info, dep_info)
+        if not isinstance(resolved_vers, ConstraintClasses):
+            raise ValueError(
+                "RuntimeDependency must be defined as version.")
+        if (
+            not resolved_vers.is_empty()
+            and parse_constraint(dep_info).allows(resolved_vers)
+        ):
+            dep_info = main_poetry[dependency]
+        else:
+            raise ValueError(
+                f"Cannot result {dependency} with"
+                f" {dep_info} for {addon_name}"
+            )
 
         if dep_info:
             main_poetry[dependency] = dep_info
@@ -487,14 +495,14 @@ def get_full_toml(base_toml_data, addon_tomls, platform_name):
     return base_toml_data
 
 
-def prepare_new_venv(full_toml_data, output_root, python_version):
+def prepare_new_venv(full_toml_data, output_root, installer):
     """Let Poetry create new venv in 'venv_folder' from 'full_toml_data'.
 
     Args:
         full_toml_data (dict): toml representation calculated based on basic
             .toml + all addon tomls.
         output_root (str): Path where venv should be created.
-        python_version (str): Python version that should be used.
+        installer (dict[str, Any]): Installer metadata.
 
     Raises:
         RuntimeError: Exception is raised if process finished with nonzero
@@ -502,6 +510,8 @@ def prepare_new_venv(full_toml_data, output_root, python_version):
     """
 
     print(f"Preparing new venv in {output_root}")
+
+    python_version = installer["pythonVersion"]
 
     python_args = get_python_arguments(output_root, python_version)
 
@@ -516,6 +526,27 @@ def prepare_new_venv(full_toml_data, output_root, python_version):
     toml_path = os.path.join(output_root, "pyproject.toml")
 
     _convert_url_constraints(full_toml_data)
+
+    installer_runtime_dependencies = copy.deepcopy(
+        installer["runtimePythonModules"]
+    )
+    runtime_dependencies = copy.deepcopy(
+        full_toml_data["ayon"]["runtimeDependencies"]
+    )
+    # Remove installer dependencies to find out if there are any other
+    #   dependencies
+    for dep in installer_runtime_dependencies:
+        runtime_dependencies.pop(dep, None)
+
+    # Store installer runtime dependencies only if are installed
+    installed_installer_runtime_deps = set()
+    if runtime_dependencies:
+        toml_dependencies = full_toml_data["tool"]["poetry"]["dependencies"]
+        for package_name, package_version in (
+            installer_runtime_dependencies.items()
+        ):
+            installed_installer_runtime_deps.add(package_name)
+            toml_dependencies[package_name] = package_version
 
     with open(toml_path, "w") as stream:
         toml.dump(full_toml_data, stream)
@@ -549,7 +580,41 @@ def prepare_new_venv(full_toml_data, output_root, python_version):
     )
     if return_code != 0:
         raise RuntimeError(f"Preparation of {venv_path} failed!")
-    return venv_path
+
+    runtime_root = os.path.join(output_root, "runtime")
+    os.makedirs(runtime_root, exist_ok=True)
+    _install_runtime_dependencies(
+        runtime_dependencies, runtime_root, poetry_bin, env
+    )
+
+    return venv_path, runtime_root, installed_installer_runtime_deps
+
+
+def _install_runtime_dependencies(
+    runtime_dependencies, runtime_root, poetry_bin, env
+):
+    """Install runtime dependencies from 'full_toml_data' to 'output_root'.
+
+    Args:
+        runtime_dependencies (dict[str, str]): Runtime dependencies with
+            requested versions.
+        runtime_root (str): Path where runtime dependencies should be created.
+        poetry_bin (str): Path to poetry executable.
+    """
+
+    for package_name, package_version in runtime_dependencies.items():
+        args = [
+            poetry_bin, "run",
+            "python", "-m", "pip", "install",
+            "--upgrade", f"{package_name}=={package_version}",
+            "-t", str(runtime_root)
+        ]
+
+        run_subprocess(
+            args,
+            env=env,
+            cwd=runtime_root
+        )
 
 
 def _convert_url_constraints(full_toml_data):
@@ -620,13 +685,19 @@ def lock_to_toml_data(lock_path):
     return {"tool": {"poetry": {"dependencies": dependencies}}}
 
 
-def remove_existing_from_venv(addons_venv_path, installer):
+def remove_existing_from_venv(
+    addons_venv_path,
+    installer,
+    installed_installer_runtime_deps
+):
     """Loop through calculated addon venv and remove already installed libs.
 
     Args:
-        addons_venv_path (str): path to newly created merged venv for active
-            addons
+        addons_venv_path (str): Path to newly created merged venv for active
+            addons.
         installer (dict[str, Any]): installer data from server.
+        installed_installer_runtime_deps (set[str]): Installed runtime
+            dependencies.
 
     Returns:
         (set) of folder/file paths that were removed from addon venv, used only
@@ -635,18 +706,22 @@ def remove_existing_from_venv(addons_venv_path, installer):
 
     pip_executable = get_venv_executable(addons_venv_path, "pip")
     print("Removing packages from venv")
-    print("\n".join([
-        f"- {package_name}"
-        for package_name in sorted(installer["pythonModules"])
-    ]))
-    for package_name in installer["pythonModules"]:
+    for package_name in sorted(
+        set(installer["pythonModules"])
+        | set(installed_installer_runtime_deps)
+    ):
+        # Fix 'Babel'
+        # TODO fix in ayon-launcher
+        if package_name == "Babel":
+            package_name = "babel"
+        print(f"- {package_name}")
         run_subprocess(
             [pip_executable, "uninstall", package_name, "--yes"],
             bound_output=False
         )
 
 
-def zip_venv(venv_folder, zip_filepath):
+def zip_venv(venv_folder, runtime_root, zip_filepath):
     """Zips newly created venv to single .zip file."""
 
     site_packages_roots = get_venv_site_packages(venv_folder)
@@ -672,12 +747,30 @@ def zip_venv(venv_folder, zip_filepath):
                     dst_path = os.path.join(dst_root, filename)
                     zipf.write(src_path, dst_path)
 
+        zip_runtime_root = "runtime"
+        for root, _, filenames in os.walk(runtime_root):
+            # Care only about files
+            if not filenames:
+                continue
 
-def prepare_zip_venv(venv_path, output_root):
+            dst_root = zip_runtime_root
+            if root != runtime_root:
+                dst_root = os.path.join(
+                    dst_root, root[len(runtime_root) + 1:]
+                )
+
+            for filename in filenames:
+                src_path = os.path.join(root, filename)
+                dst_path = os.path.join(dst_root, filename)
+                zipf.write(src_path, dst_path)
+
+
+def prepare_zip_venv(venv_path, runtime_root, output_root):
     """Handles creation of zipped venv.
 
     Args:
         venv_path (str): Path to created venv.
+        runtime_root (str): Path to runtime dependencies.
         output_root (str): Temp folder path.
 
     Returns:
@@ -687,7 +780,7 @@ def prepare_zip_venv(venv_path, output_root):
     zip_file_name = f"{create_dependency_package_basename()}.zip"
     venv_zip_path = os.path.join(output_root, zip_file_name)
     print(f"Zipping new venv to {venv_zip_path}")
-    zip_venv(venv_path, venv_zip_path)
+    zip_venv(venv_path, runtime_root, venv_zip_path)
 
     return venv_zip_path
 
@@ -965,13 +1058,26 @@ def _create_package(
         update_bundle_with_package(con, bundle, applicable_package)
         return applicable_package["filename"]
 
-    addons_venv_path = prepare_new_venv(
-        full_toml_data, output_root, installer["pythonVersion"]
+    (
+        addons_venv_path,
+        runtime_root,
+        installed_installer_runtime_deps
+    ) = prepare_new_venv(
+        full_toml_data, output_root, installer
     )
-    # remove already distributed libraries from addons specific venv
-    remove_existing_from_venv(addons_venv_path, installer)
 
-    venv_zip_path = prepare_zip_venv(addons_venv_path, output_root)
+    # remove already distributed libraries from addons specific venv
+    remove_existing_from_venv(
+        addons_venv_path,
+        installer,
+        installed_installer_runtime_deps
+    )
+
+    venv_zip_path = prepare_zip_venv(
+        addons_venv_path,
+        runtime_root,
+        output_root,
+    )
 
     package_data = prepare_package_data(venv_zip_path, bundle, platform_name)
     if destination_root:

--- a/dependencies/core.py
+++ b/dependencies/core.py
@@ -9,7 +9,6 @@ import json
 import subprocess
 import collections
 import shutil
-import itertools
 from typing import Dict, Union
 from packaging import version
 from dataclasses import dataclass

--- a/dependencies/utils.py
+++ b/dependencies/utils.py
@@ -23,6 +23,7 @@ ANSI_REGEX = re.compile(
     ),
     flags=re.IGNORECASE
 )
+PACKAGE_ROOT = os.path.dirname(os.path.abspath(__file__))
 
 
 def get_venv_executable(venv_root, executable="python"):


### PR DESCRIPTION
## Description
Depencendies tool can to some degree install runtime dependencies and add them to dependency package.

### Additional information
It can to some degree handle platform specific version and version resolution. But there is missing one part which is validating if runtime dependencies are also in standard dependencies, that is not "must have" for first iteration and we don't have that use-case at this moment.

This PR will be combination of PRs in multiple repositories (OpenPype, ayon-dependencies-tool, ayon-launcher).
- [ayon-launcher](https://github.com/ynput/ayon-launcher/pull/78)
- [ayon-dependencies-tool](https://github.com/ynput/ayon-dependencies-tool/pull/9)
- [OpenPype](https://github.com/ynput/OpenPype/pull/6095)