### PR TITLE
Use prefix for runtime dependencies

### DIFF
--- a/dependencies/_runtime_deps.py
+++ b/dependencies/_runtime_deps.py
@@ -42,7 +42,9 @@ def main():
     with open(output_path, "r") as stream:
         data = json.load(stream)
 
-    data["runtime_dependencies"] = get_runtime_modules(data["runtime_root"])
+    data["runtime_dependencies"] = get_runtime_modules(
+        data["runtime_site_packages"]
+    )
 
     print(f"Storing output to {output_path}")
     with open(output_path, "w") as stream:

--- a/dependencies/core.py
+++ b/dependencies/core.py
@@ -636,6 +636,7 @@ def _install_runtime_dependencies(
         poetry_bin (str): Path to poetry executable.
     """
 
+    requirements_lines = []
     for package_name, package_version in runtime_dependencies.items():
         parsed_version: VersionConstraint = parse_constraint(package_version)
         if parsed_version.is_any():
@@ -656,18 +657,25 @@ def _install_runtime_dependencies(
 
             package_version = f"{min_ver},{max_ver}"
 
-        args = [
-            poetry_bin, "run",
-            "python", "-m", "pip", "install",
-            "--upgrade", f"{package_name}{package_version}",
-            "--prefix", str(runtime_root)
-        ]
+        requirements_lines.append(f"{package_name}{package_version}")
 
-        run_subprocess(
-            args,
-            env=env,
-            cwd=runtime_root
-        )
+    requiements_path = os.path.join(runtime_root, "requirements.txt")
+    with open(requiements_path, "w") as stream:
+        stream.write("\n".join(requirements_lines))
+
+    args = [
+        poetry_bin, "run",
+        "python", "-m", "pip", "install",
+        "--upgrade",
+        "-r", requiements_path,
+        "--prefix", str(runtime_root)
+    ]
+
+    run_subprocess(
+        args,
+        env=env,
+        cwd=runtime_root
+    )
 
 
 def _convert_url_constraints(full_toml_data):

--- a/dependencies/core.py
+++ b/dependencies/core.py
@@ -619,11 +619,24 @@ def _install_runtime_dependencies(
     """
 
     for package_name, package_version in runtime_dependencies.items():
-        parsed_version = parse_constraint(package_version)
-        if isinstance(parsed_version, VersionRangeConstraint):
-            package_version = f">={parsed_version.min},<{parsed_version.max}"
-        else:
+        parsed_version: VersionConstraint = parse_constraint(package_version)
+        if parsed_version.is_any():
+            package_version = ""
+        elif parsed_version.is_simple():
             package_version = f"=={package_version}"
+        else:
+            min_ver = str(parsed_version.min)
+            if parsed_version.include_min:
+                min_ver = f">={min_ver}"
+            else:
+                min_ver = f">{min_ver}"
+            max_ver = str(parsed_version.max)
+            if parsed_version.include_max:
+                max_ver = f"<={max_ver}"
+            else:
+                max_ver = f"<{max_ver}"
+
+            package_version = f"{min_ver},{max_ver}"
 
         args = [
             poetry_bin, "run",

--- a/dependencies/core.py
+++ b/dependencies/core.py
@@ -601,7 +601,25 @@ def prepare_new_venv(full_toml_data, output_root, installer):
     _install_runtime_dependencies(
         runtime_dependencies, runtime_root, poetry_bin, env
     )
-    runtime_site_packages = os.path.join(runtime_root, "Lib", "site-packages")
+    if platform.system().lower() == "windows":
+        runtime_site_packages = os.path.join(
+            runtime_root, "Lib", "site-packages"
+        )
+    else:
+        lib_dir = os.path.join(runtime_root, "lib")
+        # linux and macos create python{x}.{y} subfolder (should create
+        #   only one)
+        runtime_site_packages = os.path.join(
+            lib_dir, python_version[:3], "site-packages"
+        )
+        # Fill correct path only if exists
+        if os.path.exists(lib_dir):
+            python_subdirs = list(os.listdir(lib_dir))
+            if python_subdirs:
+                python_subdir = python_subdirs[0]
+                runtime_site_packages = os.path.join(
+                    lib_dir, python_subdir, "site-packages"
+                )
 
     return venv_path, runtime_site_packages, installed_installer_runtime_deps
 

--- a/dependencies/core.py
+++ b/dependencies/core.py
@@ -610,7 +610,7 @@ def prepare_new_venv(full_toml_data, output_root, installer):
         # linux and macos create python{x}.{y} subfolder (should create
         #   only one)
         runtime_site_packages = os.path.join(
-            lib_dir, python_version[:3], "site-packages"
+            lib_dir, f"python{python_version[:3]}", "site-packages"
         )
         # Fill correct path only if exists
         if os.path.exists(lib_dir):

--- a/dependencies/core.py
+++ b/dependencies/core.py
@@ -619,10 +619,16 @@ def _install_runtime_dependencies(
     """
 
     for package_name, package_version in runtime_dependencies.items():
+        parsed_version = parse_constraint(package_version)
+        if isinstance(parsed_version, VersionRangeConstraint):
+            package_version = f">={parsed_version.min},<{parsed_version.max}"
+        else:
+            package_version = f"=={package_version}"
+
         args = [
             poetry_bin, "run",
             "python", "-m", "pip", "install",
-            "--upgrade", f"{package_name}=={package_version}",
+            "--upgrade", f"{package_name}{package_version}",
             "--prefix", str(runtime_root)
         ]
 


### PR DESCRIPTION
## Description
Use `--prefix` instead of `--target` to install runtime dependencies. Using prefix does not cause that all dependencies are installed even if are already available in existing site-packages.

This change required small change how the packages are installed and how are archived into zip, but it seems to be working now.