### PR TITLE
Fix pyenv python version

### DIFF
--- a/dependencies/core.py
+++ b/dependencies/core.py
@@ -111,7 +111,10 @@ def get_pyenv_arguments(
         [pyenv_path, "local", python_version],
         cwd=output_root
     )
-    output = subprocess.check_output([pyenv_path, "which", "python"])
+    output = subprocess.check_output(
+        [pyenv_path, "which", "python"],
+        cwd=output_root
+    )
     python_path = output.decode().strip()
     return [python_path]
 


### PR DESCRIPTION
## Description
Fix way how python executable is received by adding cwd into `which` call.

## Additional description
Pyenv will set correct version in the output directory but does not use it because the `which` argument is called for wrong directory. That is resolved by adding the output path to subprocess.

## Testing notes
1. Create AYON launcher installer with python 3.9.6 (or different version)
2. Create venv of dependencies tool with python 3.9.12 (different version from step 1.)
3. Run dependencies tool to create package for the installer
4. All should go well without erroring out on wrong python version