### PR TITLE
Docker images: Keep images alive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,9 @@ FROM ubuntu:focal AS builder
 ARG PYTHON_VERSION=3.9.13
 ARG BUILD_DATE
 ARG VERSION
-ARG BUNDLE_NAME
 
 LABEL description="Docker Image to create dependency package for Ubuntu installer"
-LABEL org.opencontainers.image.name="ynput/ayon-dependencies"
+LABEL org.opencontainers.image.name="ynput/ayon-dependencies-ubuntu"
 LABEL org.opencontainers.image.title="AYON Dependency Package Docker Image"
 LABEL org.opencontainers.image.url="https://ayon.ynput.io/"
 LABEL org.opencontainers.image.source="https://github.com/ynput/ayon-dependencies-tool"
@@ -73,5 +72,6 @@ RUN source $HOME/init_pyenv.sh \
 
 # build launcher and installer
 RUN source $HOME/.bashrc \
-    && ./start.sh install \
-    && ./start.sh create -b $BUNDLE_NAME
+    && ./start.sh install
+
+CMD [/opt/ayon-dependencies-tool/start.sh, listen]

--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -3,10 +3,9 @@ FROM centos:7 AS builder
 ARG PYTHON_VERSION=3.9.13
 ARG BUILD_DATE
 ARG VERSION
-ARG BUNDLE_NAME
 
 LABEL description="Docker Image to create dependency package for Centos 7 installer"
-LABEL org.opencontainers.image.name="ynput/ayon-dependencies"
+LABEL org.opencontainers.image.name="ynput/ayon-dependencies-centos7"
 LABEL org.opencontainers.image.title="AYON Dependency Package Docker Image"
 LABEL org.opencontainers.image.url="https://ayon.ynput.io/"
 LABEL org.opencontainers.image.source="https://github.com/ynput/ayon-dependencies-tool"
@@ -96,5 +95,6 @@ RUN source $HOME/.bashrc \
     && pyenv local ${PYTHON_VERSION}
 
 RUN source $HOME/.bashrc \
-    && ./start.sh install \
-    && ./start.sh create -b $BUNDLE_NAME
+    && ./start.sh install
+
+CMD [/opt/ayon-dependencies-tool/start.sh, listen]

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -3,10 +3,9 @@ FROM debian:bullseye AS builder
 ARG PYTHON_VERSION=3.9.13
 ARG BUILD_DATE
 ARG VERSION
-ARG BUNDLE_NAME
 
 LABEL description="Docker Image to create dependency package for Debian installer"
-LABEL org.opencontainers.image.name="ynput/ayon-dependencies"
+LABEL org.opencontainers.image.name="ynput/ayon-dependencies-debian"
 LABEL org.opencontainers.image.title="AYON Dependency Package Docker Image"
 LABEL org.opencontainers.image.url="https://ayon.ynput.io/"
 LABEL org.opencontainers.image.source="https://github.com/ynput/ayon-dependencies-tool"
@@ -72,5 +71,6 @@ RUN source $HOME/init_pyenv.sh \
 
 # create venv and create dependency package
 RUN source $HOME/.bashrc \
-    && ./start.sh install \
-    && ./start.sh create -b $BUNDLE_NAME
+    && ./start.sh install
+
+CMD [/opt/ayon-dependencies-tool/start.sh, listen]

--- a/Dockerfile.rocky8
+++ b/Dockerfile.rocky8
@@ -1,15 +1,14 @@
-# Build AYON launcher docker image
+# Build AYON dependencies docker image
 FROM rockylinux:8 AS builder
 ARG PYTHON_VERSION=3.9.13
 ARG BUILD_DATE
 ARG VERSION
-ARG BUNDLE_NAME
 
-LABEL description="Docker Image to build and run AYON Launcher under RockyLinux 8"
-LABEL org.opencontainers.image.name="ynput/ayon-launcher"
-LABEL org.opencontainers.image.title="AYON Launcher Docker Image"
+LABEL description="Docker Image to create dependency package for RockyLinux 8 installer"
+LABEL org.opencontainers.image.name="ynput/ayon-dependencies-rocky8"
+LABEL org.opencontainers.image.title="AYON Dependency Package Docker Image"
 LABEL org.opencontainers.image.url="https://ayon.ynput.io/"
-LABEL org.opencontainers.image.source="https://github.com/ynput/ayon-launcher"
+LABEL org.opencontainers.image.source="https://github.com/ynput/ayon-dependencies-tool"
 LABEL org.opencontainers.image.documentation="https://ayon.ynput.io"
 LABEL org.opencontainers.image.created=$BUILD_DATE
 LABEL org.opencontainers.image.version=$VERSION
@@ -73,5 +72,4 @@ RUN source $HOME/.bashrc \
 RUN source $HOME/.bashrc \
     && ./start.sh install
 
-RUN source $HOME/.bashrc \
-    && ./start.sh create -b $BUNDLE_NAME
+CMD [/opt/ayon-dependencies-tool/start.sh, listen]

--- a/Dockerfile.rocky9
+++ b/Dockerfile.rocky9
@@ -3,10 +3,9 @@ FROM rockylinux:9 AS builder
 ARG PYTHON_VERSION=3.9.13
 ARG BUILD_DATE
 ARG VERSION
-ARG BUNDLE_NAME
 
 LABEL description="Docker Image to create dependency package for RockyLinux 9 installer"
-LABEL org.opencontainers.image.name="ynput/ayon-dependencies"
+LABEL org.opencontainers.image.name="ynput/ayon-dependencies-rocky9"
 LABEL org.opencontainers.image.title="AYON Dependency Package Docker Image"
 LABEL org.opencontainers.image.url="https://ayon.ynput.io/"
 LABEL org.opencontainers.image.source="https://github.com/ynput/ayon-dependencies-tool"
@@ -71,5 +70,4 @@ RUN source $HOME/.bashrc \
 RUN source $HOME/.bashrc \
     && ./start.sh install
 
-RUN source $HOME/.bashrc \
-    && ./start.sh create -b $BUNDLE_NAME
+CMD [/opt/ayon-dependencies-tool/start.sh, listen]

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Entry point for manual triggering is `start.ps1` or `start.sh`.
 Implemented commands:
 - `install` - creates `./.venv` with requirements for this tool
 - `create` - runs main process to create new dependency package and uploads it. Expects argument with name of Bundle (eg. `./start create -b MyBundle`). For more information `./start create --help`.
-- `listen` - starts service connecting to Ayon server and listening for events to trigger main process (TBD)
-- `list-bundles` - lists all bundles on Ayon server
+- `listen` - starts service connecting to AYON server and listening for events to trigger main process (TBD)
+- `list-bundles` - lists all bundles on AYON server
 
 TODO:
 - [ ] force to reuse python version from Installer (make `pyenv` required)
@@ -34,4 +34,6 @@ TODO:
 - [ ] skip dependency package creation if there are not any addons with dependencies
 - [ ] Provide dockerized AYON service manageable directly by [ASH (AYON service host)](https://github.com/ynput/ash)
 - [X] Provide single-time docker to create dependency packages for linux distros
-    - [ ] be able to re-use the image for multiple runs
+    - [X] be able to re-use the image for multiple runs
+    - [ ] take environment variables from called script
+    - [ ] limit which files are copied to docker (e.g. should not contain '.env' file)

--- a/start.ps1
+++ b/start.ps1
@@ -27,7 +27,7 @@ function Default-Func {
     Write-Host "  create                           Create dependency package for single bundle."
     Write-Host "  list-bundles                     List bundles available on server."
     Write-Host "  docker-create [bundle] [variant] Create dependency package using docker. Variant can be 'centos7', 'ubuntu', 'debian' or 'rocky9'"
-    Write-Host "  build-docker [variant]           Build docker image. Variant can be 'centos7', 'ubuntu', 'debian' or 'rocky9'"
+    Write-Host "  build-docker [variant]           Build docker image. Variant can be 'centos7', 'ubuntu', 'debian', 'rocky8' or 'rocky9'"
     Write-Host ""
 }
 
@@ -75,7 +75,7 @@ function CreateDockerPrivate {
 function CreateDocker {
     $variant = $args[0]
     if ($null -eq $variant) {
-        Write-Host "!!! Missing specified variant (available options are 'centos7', 'ubuntu', 'debian' or 'rocky9')."
+        Write-Host "!!! Missing specified variant (available options are 'centos7', 'ubuntu', 'debian', 'rocky8' or 'rocky9')."
         Restore-Cwd
         Exit-WithCode 1
     }

--- a/start.ps1
+++ b/start.ps1
@@ -21,12 +21,13 @@ function Default-Func {
     Write-Host "Usage: ./start.ps1 [target]"
     Write-Host ""
     Write-Host "Runtime targets:"
-    Write-Host "  install                         Install Poetry and update venv by lock file."
-    Write-Host "  set-env                         Set all env vars in .env file."
-    Write-Host "  listen                          Start listener on a server."
-    Write-Host "  create                          Create dependency package for single bundle."
-    Write-Host "  list-bundles                    List bundles available on server."
-    Write-Host "  docker-build [bundle] [variant] Build dependency package using docker. Variant can be 'centos7', 'ubuntu', 'debian' or 'rocky9'"
+    Write-Host "  install                          Install Poetry and update venv by lock file."
+    Write-Host "  set-env                          Set all env vars in .env file."
+    Write-Host "  listen                           Start listener on a server."
+    Write-Host "  create                           Create dependency package for single bundle."
+    Write-Host "  list-bundles                     List bundles available on server."
+    Write-Host "  docker-create [bundle] [variant] Create dependency package using docker. Variant can be 'centos7', 'ubuntu', 'debian' or 'rocky9'"
+    Write-Host "  build-docker [variant]           Build docker image. Variant can be 'centos7', 'ubuntu', 'debian' or 'rocky9'"
     Write-Host ""
 }
 
@@ -56,17 +57,8 @@ function Install-Poetry() {
     (Invoke-WebRequest -Uri https://install.python-poetry.org/ -UseBasicParsing).Content | & $($python) -
 }
 
-function CreatePackageWithDocker {
-    $startTime = [int][double]::Parse((Get-Date -UFormat %s))
-    Write-Host ">>> Building AYON using Docker ..."
-    $bundleName = $args[0]
-    $variant = $args[1]
-    $imageIdPath = "$($repo_root)/docker-image.id"
-
-    if ($null -eq $variant) {
-        $variant = "ubuntu"
-    }
-
+function CreateDockerPrivate {
+    $variant = $args[0]
     if ($variant -eq "ubuntu") {
         $dockerfile = "$($repo_root)\Dockerfile"
     } else {
@@ -77,18 +69,41 @@ function CreatePackageWithDocker {
         Restore-Cwd
         Exit-WithCode 1
     }
+    docker build --pull --build-arg BUILD_DATE=$(Get-Date -UFormat %Y-%m-%dT%H:%M:%SZ) --build-arg VERSION=$TOOL_VERSION -t ynput/ayon-dependencies-$($variant):$TOOL_VERSION -f $dockerfile .
+}
+
+function CreateDocker {
+    $variant = $args[0]
+    if ($null -eq $variant) {
+        Write-Host "!!! Missing specified variant (available options are 'centos7', 'ubuntu', 'debian' or 'rocky9')."
+        Restore-Cwd
+        Exit-WithCode 1
+    }
+    CreateDockerPrivate $variant
+}
+
+function CreatePackageWithDocker {
+    $startTime = [int][double]::Parse((Get-Date -UFormat %s))
+    Write-Host ">>> Building AYON dependency package using Docker ..."
+    $bundleName = $args[0]
+    $variant = $args[1]
+    if ($null -eq $bundleName -or $null -eq $variant) {
+        Write-Host "!!! Please use 'docker-create' command with [bundle name] [variant] arguments."
+        Restore-Cwd
+        Exit-WithCode 1
+    }
+
+    $imageName = "ynput/ayon-dependencies-$($variant):$TOOL_VERSION"
+    Write-Host "Using image name '$imageName'"
+
+    if (!(docker images -q $imageName 2> $null)) {
+        CreateDockerPrivate $variant
+    }
 
     Write-Host ">>> Running Docker build ..."
-
-    if (Test-Path $imageIdPath) {
-        Remove-Item $imageIdPath
-    }
-    docker build --pull --iidfile $imageIdPath --build-arg BUILD_DATE=$(Get-Date -UFormat %Y-%m-%dT%H:%M:%SZ) --build-arg VERSION=$TOOL_VERSION --build-arg BUNDLE_NAME=$bundleName -t ynput/ayon-dependencies:$TOOL_VERSION-$variant -f $dockerfile .
-    if (Test-Path $imageIdPath) {
-        $cid = Get-Content $imageIdPath
-        Remove-Item $imageIdPath
-        docker image rm $cid
-    }
+    $containerName = Get-Date -UFormat %Y%m%dT%H%M%SZ
+    docker run --name $containerName -it --entrypoint "/bin/bash" $imageName -c "/opt/ayon-dependencies-tool/start.sh create -b $bundleName"
+    docker container rm $containerName
 
     if ($LASTEXITCODE -ne 0) {
         Write-Host "!!! Docker command failed. $LASTEXITCODE"
@@ -164,9 +179,12 @@ function main {
         Change-Cwd
         set_env
         & "$env:POETRY_HOME\bin\poetry" run python "$($repo_root)\dependencies" list-bundles @arguments
-    } elseif ($FunctionName -eq "dockerbuild") {
+    } elseif ($FunctionName -eq "dockercreate") {
         Change-Cwd
         CreatePackageWithDocker @arguments
+    } elseif ($FunctionName -eq "builddocker") {
+        Change-Cwd
+        CreateDocker @arguments
     } else {
         Write-Host "Unknown function \"$FunctionName\""
         Default-Func

--- a/start.sh
+++ b/start.sh
@@ -205,7 +205,7 @@ create_docker_image_private() {
 create_docker_image() {
   variant=$1
   if [ -z "$variant" ]; then
-    echo -e "${BIRed}!!!${RST} !!! Missing variant (available options are '${BIWhite}centos7${RST}', '${BIWhite}ubuntu${RST}', '${BIWhite}debian${RST}' or '${BIWhite}rocky9${RST}')."
+    echo -e "${BIRed}!!!${RST} !!! Missing variant (available options are '${BIWhite}centos7${RST}', '${BIWhite}ubuntu${RST}', '${BIWhite}debian${RST}', '${BIWhite}rocky8${RST}', '${BIWhite}rocky8${RST}' or '${BIWhite}rocky9${RST}')."
     exit 1
   fi
   create_docker_image_private $variant
@@ -253,8 +253,8 @@ default_help() {
   echo "  listen                           Start listener on a server."
   echo "  create                           Create dependency package for single bundle."
   echo "  list-bundles                     List bundles available on server."
-  echo "  docker-create [bundle] [variant] Create dependency package using docker. Variant can be 'centos7', 'ubuntu', 'debian' or 'rocky9'"
-  echo "  build-docker [variant]           Build docker image. Variant can be 'centos7', 'ubuntu', 'debian' or 'rocky9'"
+  echo "  docker-create [bundle] [variant] Create dependency package using docker. Variant can be 'centos7', 'ubuntu', 'debian', 'rocky8' or 'rocky9'"
+  echo "  build-docker [variant]           Build docker image. Variant can be 'centos7', 'ubuntu', 'debian', 'rocky8' or 'rocky9'"
   echo ""
 }
 


### PR DESCRIPTION
## Description
Changed docker workflow to be able to create and re-use images instead of creating it again on each re-run.

### Additional information
Each dockerfile now has variant name in image name so they don't collide, for tag is used version of dependencies tool. This helps to avoid building full image all the time, when image is available it just runs create dependency package logic.

It still uses environment variables from `.env` file inside docker image which should not happen (future enhancements).