### PR TITLE
Scripts: Use --login in docker-create

### DIFF
--- a/start.ps1
+++ b/start.ps1
@@ -102,7 +102,7 @@ function CreatePackageWithDocker {
 
     Write-Host ">>> Running Docker build ..."
     $containerName = Get-Date -UFormat %Y%m%dT%H%M%SZ
-    docker run --name $containerName -it --entrypoint "/bin/bash" $imageName -c "/opt/ayon-dependencies-tool/start.sh create -b $bundleName"
+    docker run --name $containerName -it --entrypoint "/bin/bash" $imageName -l -c "/opt/ayon-dependencies-tool/start.sh create -b $bundleName"
     docker container rm $containerName
 
     if ($LASTEXITCODE -ne 0) {

--- a/start.sh
+++ b/start.sh
@@ -229,7 +229,7 @@ create_package_with_docker() {
 
   echo -e "${BIGreen}>>>${RST} Running docker build ..."
   container_name=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-  docker run --name $container_name -it --entrypoint "/bin/bash" $image_name -c "/opt/ayon-dependencies-tool/start.sh create -b $bundle_name"
+  docker run --name $container_name -it --entrypoint "/bin/bash" $image_name -l -c "/opt/ayon-dependencies-tool/start.sh create -b $bundle_name"
   docker container rm $containerName
 
   if [ $? -ne 0 ] ; then


### PR DESCRIPTION
## Changelog Description
Added `-l` argument to `/bin/bash` for `docker-create` so bash reloads `~/.bashrc`.

## Additional info
This will cause that `pyenv` and `python` defined in `~/.bashrc` are actually available and creation can happen.

## Testing notes:
1. Running `./start.ps1 docker-create <YOUR BUNDLE NAME> <DOCKER FILE e.g. rocky9>`
2. It should start resolving dependencies.
