### PR TITLE
Chore: Add python version and distro short to metadata

### DIFF
--- a/dependencies/core.py
+++ b/dependencies/core.py
@@ -1079,6 +1079,7 @@ def prepare_package_data(
 
     return {
         "filename": package_name,
+        "distro_short ": distro_short,
         "python_version": python_version,
         "python_modules": python_modules,
         "source_addons": copy.deepcopy(addons),

--- a/dependencies/core.py
+++ b/dependencies/core.py
@@ -1046,6 +1046,7 @@ def calculate_hash(filepath):
 
 def prepare_package_data(
     venv_zip_path: str,
+    python_version: str,
     addons: dict[str, str],
     installer_version: str,
     runtime_dependencies: dict[str, str],
@@ -1072,8 +1073,13 @@ def prepare_package_data(
     package_name = os.path.basename(venv_zip_path)
     checksum = calculate_hash(venv_zip_path)
 
+    distro_short = None
+    if PLATFORM_NAME == "linux":
+        distro_short = f"{distro.id()}{distro.major_version()}"
+
     return {
         "filename": package_name,
+        "python_version": python_version,
         "python_modules": python_modules,
         "source_addons": copy.deepcopy(addons),
         "installer_version": installer_version,
@@ -1388,6 +1394,7 @@ def _create_package(
 
     package_data = prepare_package_data(
         venv_zip_path,
+        venv_info.python_version,
         addons,
         installer["version"],
         runtime_dependencies,


### PR DESCRIPTION
## Changelog Description
Added python version and distro short to dependencies metadata file.

## Additional review information
Dependency package metadata now have `python_version` and `distro_short`.

## Testing notes:
1. Create dependency package for a bundle.
2. Check created metadata json file if contains python version and distro short.
