### PR TITLE
deactivate existing venv and update path

### DIFF
--- a/start.ps1
+++ b/start.ps1
@@ -109,7 +109,7 @@ function CreatePackageWithDocker {
 
 function Change-Cwd() {
     Set-Location -Path $repo_root
-    $unmanaged_uv = "$repo_root\.uv\bin"
+    $unmanaged_uv = "$repo_root\.uv"
     if (Test-Path -PathType Container -Path $unmanaged_uv){
         $pathParts = @($env:PATH -split ';' | Where-Object {
             $_ -and ($_ -ne $unmanaged_uv)

--- a/start.ps1
+++ b/start.ps1
@@ -109,8 +109,12 @@ function CreatePackageWithDocker {
 
 function Change-Cwd() {
     Set-Location -Path $repo_root
-    if (-not (Get-Command "uv" -ErrorAction SilentlyContinue)) {
-        $env:PATH = "$repo_root\.uv;$env:PATH"
+    $unmanaged_uv = "$repo_root\.uv\bin"
+    if (Test-Path -PathType Container -Path $unmanaged_uv){
+        $pathParts = @($env:PATH -split ';' | Where-Object {
+            $_ -and ($_ -ne $unmanaged_uv)
+        })
+        $env:PATH = @($unmanaged_uv) + $pathParts -join ';'
     }
 
 }

--- a/start.ps1
+++ b/start.ps1
@@ -165,7 +165,7 @@ function main {
     } elseif ($FunctionName -eq "listen") {
         Change-Cwd
         set_env
-        & "$repo_root\.venv\Scripts\python.exe" "$($repo_root)\service" @arguments
+        & uv run python "$($repo_root)\service" @arguments
     } elseif ($FunctionName -eq "setenv") {
         Change-Cwd
         set_env

--- a/start.ps1
+++ b/start.ps1
@@ -172,7 +172,7 @@ function main {
     } elseif ($FunctionName -eq "create") {
         Change-Cwd
         set_env
-        & "$repo_root\.venv\Scripts\python.exe" "$($repo_root)\dependencies" create @arguments
+        & uv run python "$($repo_root)\dependencies" create @arguments
     } elseif ($FunctionName -eq "listbundles") {
         Change-Cwd
         set_env

--- a/start.ps1
+++ b/start.ps1
@@ -108,11 +108,6 @@ function CreatePackageWithDocker {
 }
 
 function Change-Cwd() {
-    if ($env:VIRTUAL_ENV) {
-        Write-Host ">>> Deactivating existing venv: $env:VIRTUAL_ENV"
-        $env:VIRTUAL_ENV = $null
-        $env:VIRTUAL_ENV_PROMPT = $null
-    }
     Set-Location -Path $repo_root
     if (-not (Get-Command "uv" -ErrorAction SilentlyContinue)) {
         $env:PATH = "$repo_root\.uv;$env:PATH"

--- a/start.ps1
+++ b/start.ps1
@@ -176,7 +176,7 @@ function main {
     } elseif ($FunctionName -eq "listbundles") {
         Change-Cwd
         set_env
-        & "$repo_root\.venv\Scripts\python.exe" "$($repo_root)\dependencies" list-bundles @arguments
+        & uv run python "$($repo_root)\dependencies" list-bundles @arguments
     } elseif ($FunctionName -eq "dockercreate") {
         Change-Cwd
         set_env

--- a/start.ps1
+++ b/start.ps1
@@ -46,9 +46,6 @@ function Install-Uv() {
     Write-Host ">>> Installing uv ..."
     $env:UV_UNMANAGED_INSTALL = "$repo_root\.uv"
     Invoke-WebRequest -Uri "https://astral.sh/uv/install.ps1" -UseBasicParsing | Invoke-Expression
-    if (-not (Get-Command "uv" -ErrorAction SilentlyContinue)) {
-        $env:PATH = "$repo_root\.uv\bin;$env:PATH"
-    }
 }
 
 function CreateDockerPrivate {
@@ -111,7 +108,16 @@ function CreatePackageWithDocker {
 }
 
 function Change-Cwd() {
+    if ($env:VIRTUAL_ENV) {
+        Write-Host ">>> Deactivating existing venv: $env:VIRTUAL_ENV"
+        $env:VIRTUAL_ENV = $null
+        $env:VIRTUAL_ENV_PROMPT = $null
+    }
     Set-Location -Path $repo_root
+    if (-not (Get-Command "uv" -ErrorAction SilentlyContinue)) {
+        $env:PATH = "$repo_root\.uv;$env:PATH"
+    }
+
 }
 
 function Restore-Cwd() {


### PR DESCRIPTION
## Changelog Description
When there is an existing activated venv uv seems to always use that one instead of the "dependency" tool venv.
Also if there is no UV in PATH at least here the install did not end up in /uv/bin but just under /uv 
 
## Testing notes:
1. Remove UV
2. start start.ps1 in an activated venv (pycharm users tend to run around in activated venvs all the time)
3. watch your local venv being "manipulated"

For the uv bin.
1. Remove UV
2. run .\start.ps1 create -b "bundlename" --skip-upload --output-dir "c:/out"     
3. uv is still not present, the install path should lead to /uv instead of /uv/bin 
