### PR TITLE
UV Fixes: Start scripts & uv usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 package/*
 
+/.uv
 /.env
 /.venv
 /.poetry

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -55,6 +55,6 @@ ENV PATH="/root/.local/bin/:$PATH"
 
 # create venv and create dependency package
 WORKDIR /opt/ayon-dependencies-tool
-RUN source $HOME/.bash_profile && ./start.sh install
+RUN source $HOME/.bashrc && ./start.sh install
 
 CMD [/opt/ayon-dependencies-tool/start.sh, listen]

--- a/dependencies/core.py
+++ b/dependencies/core.py
@@ -1329,9 +1329,7 @@ def _create_bundle_package(
         output_root, installer["pythonVersion"]
     )
 
-    solve_dependencies(
-        full_toml_data, installer["pythonVersion"], venv_info
-    )
+    solve_dependencies(full_toml_data, venv_info)
 
     applicable_package = get_applicable_package(con, full_toml_data)
     if applicable_package:
@@ -1383,11 +1381,7 @@ def _create_package(
             installer_toml_data,
             bundle_addons_toml,
         )
-        solve_dependencies(
-            full_toml_data,
-            installer["pythonVersion"],
-            venv_info,
-        )
+        solve_dependencies(full_toml_data, venv_info)
 
     (
         runtime_site_packages,

--- a/dependencies/core.py
+++ b/dependencies/core.py
@@ -39,6 +39,7 @@ from .utils import (
     ZipFileLongPaths,
     get_venv_site_packages,
     PACKAGE_ROOT,
+    VenvInfo,
 )
 from .custom_solver import solve_dependencies
 
@@ -555,21 +556,6 @@ def get_full_toml(base_toml_data, addon_tomls):
         print(f"  - {key} ({value})")
 
     return toml_data
-
-
-class VenvInfo:
-    def __init__(
-        self, root, venv_path, python_version
-    ):
-        self.root = root
-        self.venv_path = venv_path
-        self.python_version = python_version
-
-    @property
-    def venv_python(self):
-        if PLATFORM_NAME == "windows":
-            return os.path.join(self.venv_path, "Scripts", "python.exe")
-        return os.path.join(self.venv_path, "bin", "python")
 
 
 def _find_uv() -> str:

--- a/dependencies/core.py
+++ b/dependencies/core.py
@@ -40,6 +40,8 @@ from .utils import (
     get_venv_site_packages,
     PACKAGE_ROOT,
     VenvInfo,
+    get_venv_executable,
+    get_venv_python_version,
 )
 from .custom_solver import solve_dependencies
 
@@ -576,7 +578,9 @@ def _find_uv() -> str:
     )
 
 
-def prepare_new_venv(output_root, python_version):
+def prepare_new_venv(
+    output_root: str, python_version: str
+) -> VenvInfo:
     """Create a new virtual environment using uv.
 
     Args:
@@ -593,14 +597,11 @@ def prepare_new_venv(output_root, python_version):
 
     uv_bin = _find_uv()
 
-    venv_info = VenvInfo(
-        output_root,
-        os.path.join(output_root, ".venv"),
-        python_version
-    )
+    venv_path = os.path.join(output_root, ".venv")
+
     return_code = run_subprocess(
         [uv_bin, "python", "install", python_version],
-        venv_info=venv_info,
+        cwd=output_root,
     )
     if return_code != 0:
         raise RuntimeError(
@@ -609,7 +610,7 @@ def prepare_new_venv(output_root, python_version):
 
     return_code = run_subprocess(
         [uv_bin, "python", "pin", python_version],
-        venv_info=venv_info,
+        cwd=output_root,
     )
     if return_code != 0:
         raise RuntimeError(
@@ -618,35 +619,39 @@ def prepare_new_venv(output_root, python_version):
 
     return_code = run_subprocess(
         [
-            uv_bin, "venv", venv_info.venv_path, "--python", python_version
+            uv_bin, "venv", venv_path, "--python", python_version
         ],
-        venv_info=venv_info,
+        cwd=output_root,
     )
     if return_code != 0:
         raise RuntimeError(
-            f"Failed to create virtual environment at {venv_info.venv_path}"
+            f"Failed to create virtual environment at {venv_path}"
         )
 
-    venv_version = subprocess.check_output(
-        [
-            uv_bin,
-            "run", "python",
-            "-c", "import platform; print(platform.python_version())"
-        ],
-        cwd=venv_info.root,
-        text=True,
-    ).strip()
+    venv_version = get_venv_python_version(
+        uv_bin,
+        output_root
+    )
     if venv_version != python_version:
         raise RuntimeError(
             f"Creted venv with wrong python version: {venv_version}"
             f" expected: {python_version}"
         )
 
-    return venv_info
+    executable_path = get_venv_executable(uv_bin, output_root)
+
+    return VenvInfo(
+        output_root,
+        venv_path,
+        python_version,
+        executable_path,
+    )
 
 
 def install_dependencies(
-    full_toml_data, installer, venv_info: VenvInfo
+    full_toml_data: dict[str, Any],
+    installer: dict[str, Any],
+    venv_info: VenvInfo,
 ):
     """Install dependencies into the venv using uv.
 
@@ -706,7 +711,7 @@ def install_dependencies(
             uv_bin, "pip", "install",
             "-r", requirements_path,
         ],
-        cwd=venv_info.root,
+        venv_info=venv_info,
     )
     if return_code != 0:
         raise RuntimeError(f"Preparation of {venv_info.venv_path} failed!")
@@ -717,6 +722,7 @@ def install_dependencies(
         runtime_dependencies,
         runtime_root,
         uv_bin,
+        venv_info,
     )
     if PLATFORM_NAME == "windows":
         runtime_site_packages = os.path.join(
@@ -748,7 +754,10 @@ def _dep_value_to_requirement(name: str, value) -> Optional[str]:
 
 
 def _install_runtime_dependencies(
-    runtime_dependencies, runtime_root, uv_bin
+    runtime_dependencies: dict[str, str],
+    runtime_root: str,
+    uv_bin: str,
+    venv_info: VenvInfo,
 ):
     """Install runtime dependencies to a custom prefix directory.
 
@@ -757,6 +766,8 @@ def _install_runtime_dependencies(
             resolved exact versions.
         runtime_root (str): Path where runtime dependencies should be installed.
         uv_bin (str): Path to the uv executable.
+        venv_info: Venv metadata returned by prepare_new_venv.
+
     """
     requirements_lines = []
     for package_name, package_version in runtime_dependencies.items():
@@ -791,7 +802,7 @@ def _install_runtime_dependencies(
             "-r", requirements_path,
             "--prefix", str(runtime_root),
         ],
-        cwd=runtime_root,
+        venv_info=venv_info,
     )
 
 
@@ -899,7 +910,6 @@ def remove_existing_from_venv(
 
     run_subprocess(
         [uv_bin, "pip", "uninstall"] + packages,
-        bound_output=False,
         cwd=venv_info.root,
     )
 
@@ -1215,23 +1225,10 @@ def is_file_deletable(filepath):
 
 
 def get_runtime_dependencies(
-    runtime_site_packages: str, addons_venv_path: str
+    runtime_site_packages: str, venv_info: VenvInfo
 ) -> dict[str, str]:
     
     uv_bin = _find_uv()
-
-    # find out python version of created venv to add 'importlib_metadata' for python < 3.10
-    python_version = subprocess.check_output(
-        [
-            uv_bin, "run", "python",
-            "-c", "import platform;print(platform.python_version())"
-        ],
-        text=True,
-        cwd=addons_venv_path,
-    ).strip()
-    
-    #add importlib_metadata to runtime dependencies if python version is lower than 3.10
-    print(f">>> Python version: {python_version}")
 
     script_path = os.path.join(PACKAGE_ROOT, "_runtime_deps.py")
 
@@ -1248,8 +1245,8 @@ def get_runtime_dependencies(
 
     try:
         subprocess.run(
-            ["uv", "run", "python", script_path, output_path],
-            cwd=addons_venv_path,
+            [uv_bin, "run", "python", script_path, output_path],
+            cwd=venv_info.root,
         )
         with open(output_path) as stream:
             data = json.load(stream)
@@ -1332,7 +1329,9 @@ def _create_bundle_package(
         output_root, installer["pythonVersion"]
     )
 
-    solve_dependencies(full_toml_data, installer["pythonVersion"])
+    solve_dependencies(
+        full_toml_data, installer["pythonVersion"], venv_info
+    )
 
     applicable_package = get_applicable_package(con, full_toml_data)
     if applicable_package:
@@ -1369,9 +1368,9 @@ def _create_package(
     bundle_addons_toml: dict[str, Any],
     output_root: str,
     *,
-    venv_info: Optional[VenvInfo] = None,
-    full_toml_data: Optional[dict[str, Any]] = None,
-):
+    venv_info: VenvInfo | None = None,
+    full_toml_data: dict[str, Any] | None = None,
+) -> tuple[dict[str, Any], str]:
     if venv_info is None:
         venv_info = prepare_new_venv(
             output_root,
@@ -1387,6 +1386,7 @@ def _create_package(
         solve_dependencies(
             full_toml_data,
             installer["pythonVersion"],
+            venv_info,
         )
 
     (
@@ -1405,7 +1405,7 @@ def _create_package(
         installed_installer_runtime_deps
     )
     runtime_dependencies = get_runtime_dependencies(
-        runtime_site_packages, venv_info.venv_path
+        runtime_site_packages, venv_info
     )
 
     venv_zip_path = prepare_zip_venv(

--- a/dependencies/core.py
+++ b/dependencies/core.py
@@ -593,27 +593,56 @@ def prepare_new_venv(output_root, python_version):
 
     uv_bin = _find_uv()
 
-    venv_path = os.path.join(output_root, ".venv")
+    venv_info = VenvInfo(
+        output_root,
+        os.path.join(output_root, ".venv"),
+        python_version
+    )
+    return_code = run_subprocess(
+        [uv_bin, "python", "install", python_version],
+        venv_info=venv_info,
+    )
+    if return_code != 0:
+        raise RuntimeError(
+            f"Failed to install python {python_version}"
+        )
 
     return_code = run_subprocess(
         [uv_bin, "python", "pin", python_version],
-        cwd=output_root,
+        venv_info=venv_info,
     )
     if return_code != 0:
         raise RuntimeError(
-            f"Failed to create virtual environment at {venv_path}"
+            f"Failed to pin python {python_version}"
         )
 
     return_code = run_subprocess(
-        [uv_bin, "venv", venv_path],
-        cwd=output_root,
+        [
+            uv_bin, "venv", venv_info.venv_path, "--python", python_version
+        ],
+        venv_info=venv_info,
     )
     if return_code != 0:
         raise RuntimeError(
-            f"Failed to create virtual environment at {venv_path}"
+            f"Failed to create virtual environment at {venv_info.venv_path}"
         )
 
-    return VenvInfo(output_root, venv_path, python_version)
+    venv_version = subprocess.check_output(
+        [
+            uv_bin,
+            "run", "python",
+            "-c", "import platform; print(platform.python_version())"
+        ],
+        cwd=venv_info.root,
+        text=True,
+    ).strip()
+    if venv_version != python_version:
+        raise RuntimeError(
+            f"Creted venv with wrong python version: {venv_version}"
+            f" expected: {python_version}"
+        )
+
+    return venv_info
 
 
 def install_dependencies(

--- a/dependencies/core.py
+++ b/dependencies/core.py
@@ -910,7 +910,7 @@ def remove_existing_from_venv(
 
     run_subprocess(
         [uv_bin, "pip", "uninstall"] + packages,
-        cwd=venv_info.root,
+        venv_info=venv_info,
     )
 
 

--- a/dependencies/core.py
+++ b/dependencies/core.py
@@ -170,6 +170,7 @@ def get_installer_toml(installer: dict[str, Any]) -> dict[str, Any]:
     """
 
     python_modules = copy.deepcopy(installer["pythonModules"])
+    python_modules.update(installer["runtimePythonModules"])
     python_modules["python"] = installer["pythonVersion"]
     return {
         "tool": {
@@ -186,9 +187,7 @@ def get_installer_toml(installer: dict[str, Any]) -> dict[str, Any]:
             }
         },
         "ayon": {
-            "runtimeDependencies": copy.deepcopy(
-                installer["runtimePythonModules"]
-            )
+            "runtimeDependencies": {}
         }
     }
 
@@ -797,8 +796,8 @@ def _install_runtime_dependencies(
     run_subprocess(
         [
             uv_bin, "pip", "install",
-            "--upgrade",
             "-r", requirements_path,
+            "--no-deps",
             "--prefix", str(runtime_root),
         ],
         venv_info=venv_info,

--- a/dependencies/core.py
+++ b/dependencies/core.py
@@ -484,14 +484,14 @@ def _version_parse(version_value):
     return version.parse(version_value)
 
 
-def get_full_toml(base_toml_data, addon_tomls):
+def get_full_toml(installer_toml_data, addon_tomls):
     """Loops through list of local addon folder paths to create full .toml
 
     Full toml is used to calculate set of python dependencies for all enabled
     addons.
 
     Args:
-        base_toml_data (dict[str, Any]): Content of pyproject.toml from
+        installer_toml_data (dict[str, Any]): Content of pyproject.toml from
             ayon-launcher installer.
         addon_tomls (dict[str, Any]): Content of addon pyproject.toml
 
@@ -500,7 +500,7 @@ def get_full_toml(base_toml_data, addon_tomls):
     """
 
     # Fix git sources of installer dependencies
-    toml_data = copy.deepcopy(base_toml_data)
+    toml_data = copy.deepcopy(installer_toml_data)
     main_dependencies = toml_data["tool"]["poetry"]["dependencies"]
     modified_dependencies = {}
     for key, value in main_dependencies.items():
@@ -684,8 +684,8 @@ def install_dependencies(
 
     # Store installer runtime dependencies only if are installed
     installed_installer_runtime_deps = set()
+    toml_dependencies = full_toml_data["tool"]["poetry"]["dependencies"]
     if runtime_dependencies:
-        toml_dependencies = full_toml_data["tool"]["poetry"]["dependencies"]
         for package_name, package_version in (
             installer_runtime_dependencies.items()
         ):
@@ -694,7 +694,6 @@ def install_dependencies(
 
     # Build requirements list from the merged toml data
     requirements_lines = []
-    toml_dependencies = full_toml_data["tool"]["poetry"]["dependencies"]
     for name, value in toml_dependencies.items():
         if name.lower() == "python":
             continue

--- a/dependencies/custom_solver.py
+++ b/dependencies/custom_solver.py
@@ -18,6 +18,8 @@ import tempfile
 from dataclasses import dataclass
 from typing import Any, Optional
 
+from .utils import VenvInfo
+
 
 # ---------------------------------------------------------------------------
 # Public entry point
@@ -26,6 +28,7 @@ from typing import Any, Optional
 def solve_dependencies(
     full_toml_data: dict[str, Any],
     python_version: str,
+    venv_info: VenvInfo,
 ) -> None:
     """Resolve all dependencies and pin runtimeDependencies to exact versions.
 
@@ -53,10 +56,10 @@ def solve_dependencies(
         all_deps.setdefault(k, v)
 
     print("Resolving all dependencies with uv ...")
-    all_resolved = _uv_compile(all_deps, python_version)
+    all_resolved = _uv_compile(all_deps, python_version, venv_info)
 
     print("Resolving main dependency transitive closure with uv ...")
-    main_resolved_names = set(_uv_compile(main_deps, python_version))
+    main_resolved_names = set(_uv_compile(main_deps, python_version, venv_info))
 
     # runtime-only = packages resolved that are NOT in the main transitive closure
     new_runtime: dict[str, str] = {}
@@ -82,6 +85,7 @@ class _Package:
 def _uv_compile(
     deps: dict[str, Any],
     python_version: str,
+    venv_info: VenvInfo,
 ) -> dict[str, str]:
     """Run `uv pip compile` and return a dict of {normalised_name: version}.
 
@@ -112,6 +116,16 @@ def _uv_compile(
         with open(req_in, "w") as f:
             f.write("\n".join(requirements_lines) + "\n")
 
+        env = os.environ.copy()
+        env["VIRTUAL_ENV"] = venv_info.venv_path
+        env["PWD"] = venv_info.root
+        env["PATH"] = os.pathsep.join([
+            os.path.dirname(venv_info.executable_path),
+            env["PATH"]
+        ])
+        for key, value in sorted(env.items()):
+            print(key, value)
+
         cmd = [
             uv_bin, "pip", "compile",
             req_in,
@@ -125,8 +139,10 @@ def _uv_compile(
         print(f"Running: {' '.join(cmd)}")
         result = subprocess.run(
             cmd,
+            env=env,
             capture_output=False,
             text=True,
+            cwd=venv_info.root,
         )
         if result.returncode != 0:
             raise RuntimeError(

--- a/dependencies/custom_solver.py
+++ b/dependencies/custom_solver.py
@@ -27,7 +27,6 @@ from .utils import VenvInfo
 
 def solve_dependencies(
     full_toml_data: dict[str, Any],
-    python_version: str,
     venv_info: VenvInfo,
 ) -> None:
     """Resolve all dependencies and pin runtimeDependencies to exact versions.
@@ -56,10 +55,11 @@ def solve_dependencies(
         all_deps.setdefault(k, v)
 
     print("Resolving all dependencies with uv ...")
-    all_resolved = _uv_compile(all_deps, python_version, venv_info)
+    all_resolved = _uv_compile(all_deps, venv_info)
 
     print("Resolving main dependency transitive closure with uv ...")
-    main_resolved_names = set(_uv_compile(main_deps, python_version, venv_info))
+    main_resolved = _uv_compile(main_deps, venv_info)
+    main_resolved_names = set(main_resolved)
 
     # runtime-only = packages resolved that are NOT in the main transitive closure
     new_runtime: dict[str, str] = {}
@@ -84,7 +84,6 @@ class _Package:
 
 def _uv_compile(
     deps: dict[str, Any],
-    python_version: str,
     venv_info: VenvInfo,
 ) -> dict[str, str]:
     """Run `uv pip compile` and return a dict of {normalised_name: version}.
@@ -123,8 +122,6 @@ def _uv_compile(
             os.path.dirname(venv_info.executable_path),
             env["PATH"]
         ])
-        for key, value in sorted(env.items()):
-            print(key, value)
 
         cmd = [
             uv_bin, "pip", "compile",
@@ -133,8 +130,6 @@ def _uv_compile(
             "--no-header",
             "--quiet",
         ]
-        if python_version:
-            cmd += ["--python-version", python_version]
 
         print(f"Running: {' '.join(cmd)}")
         result = subprocess.run(

--- a/dependencies/utils.py
+++ b/dependencies/utils.py
@@ -7,9 +7,28 @@ import platform
 import zipfile
 
 PACKAGE_ROOT = os.path.dirname(os.path.abspath(__file__))
+PLATFORM_NAME = platform.system().lower()
 
 
-def get_venv_executable(uv_bin, venv_root):
+class VenvInfo:
+    def __init__(
+        self,
+        root: str,
+        venv_path: str,
+        python_version: str,
+    ):
+        self.root: str = root
+        self.venv_path: str = venv_path
+        self.python_version: str = python_version
+
+    @property
+    def venv_python(self) -> str:
+        if PLATFORM_NAME == "windows":
+            return os.path.join(self.venv_path, "Scripts", "python.exe")
+        return os.path.join(self.venv_path, "bin", "python")
+
+
+def get_venv_executable(uv_bin: str, venv_root: str) -> str:
     """Get path to executable in virtual environment.
 
     Args:

--- a/dependencies/utils.py
+++ b/dependencies/utils.py
@@ -16,27 +16,43 @@ class VenvInfo:
         root: str,
         venv_path: str,
         python_version: str,
+        executable_path: str,
     ):
         self.root: str = root
         self.venv_path: str = venv_path
         self.python_version: str = python_version
-
-    @property
-    def venv_python(self) -> str:
-        if PLATFORM_NAME == "windows":
-            return os.path.join(self.venv_path, "Scripts", "python.exe")
-        return os.path.join(self.venv_path, "bin", "python")
+        self.executable_path: str = executable_path
 
 
 def get_venv_executable(uv_bin: str, venv_root: str) -> str:
     """Get path to executable in virtual environment.
 
     Args:
+        uv_bin (str): Path to uv binary.
         venv_root (str): Path to venv root.
-    """
 
+    """
     return subprocess.check_output(
         [uv_bin, "run", "python", "-c" "import sys;print(sys.executable)"],
+        text=True,
+        cwd=venv_root,
+    ).strip()
+
+
+def get_venv_python_version(uv_bin: str, venv_root: str) -> str:
+    """Get path to executable in virtual environment.
+
+    Args:
+        uv_bin (str): Path to uv binary.
+        venv_root (str): Path to venv root.
+
+    """
+    return subprocess.check_output(
+        [
+            uv_bin,
+            "run", "python",
+            "-c", "import platform; print(platform.python_version())"
+        ],
         text=True,
         cwd=venv_root,
     ).strip()
@@ -64,7 +80,7 @@ def get_venv_site_packages(venv_root):
 
 
 def run_subprocess(
-    cmd_args, *args, bound_output=True, **kwargs
+    cmd_args, *args, venv_info: VenvInfo | None = None, **kwargs
 ):
     """Convenience method for getting output errors for subprocess.
 
@@ -76,7 +92,6 @@ def run_subprocess(
         cmd_args (Union[Iterable[str], str]): Command or list of arguments
             passed to Popen.
         *args: Variable length arument list passed to Popen.
-        bound_output (bool): Output will be printed with bounded margins.
         **kwargs : Arbitrary keyword arguments passed to Popen. Is possible to
             pass `logging.Logger` object under "logger" if want to use
             different than lib's logger.
@@ -94,6 +109,15 @@ def run_subprocess(
     env = kwargs.get("env") or os.environ
     # Make sure environment contains only strings
     filtered_env = {str(k): str(v) for k, v in env.items()}
+
+    if venv_info is not None:
+        if "cwd" not in kwargs:
+            kwargs["cwd"] = venv_info.root
+        filtered_env["VIRTUAL_ENV"] = venv_info.venv_path
+        filtered_env["PATH"] = os.pathsep.join([
+            os.path.dirname(venv_info.executable_path),
+            filtered_env["PATH"]
+        ])
 
     # set overrides
     kwargs["env"] = filtered_env

--- a/start.ps1
+++ b/start.ps1
@@ -115,7 +115,7 @@ function CreatePackageWithDocker {
 
 function Change-Cwd() {
     Set-Location -Path $repo_root
-    if (Test-Path -PathType Container -Path $local_uv_path) {
+    if (Test-Path -PathType Container -Path $local_uv_root) {
         # Keep local uv first in PATH, but avoid duplicates.
         $pathParts = @($env:PATH -split ';' | Where-Object {
             $_ -and ($_ -ne $local_uv_root)

--- a/start.ps1
+++ b/start.ps1
@@ -7,6 +7,8 @@ if ($ARGS.Length -gt 1) {
 $current_dir = Get-Location
 $repo_root_rel = Split-Path -Path $MyInvocation.MyCommand.Definition -Parent
 $repo_root = (Get-Item $repo_root_rel).FullName
+$local_uv_root = "$repo_root\.uv"
+$local_uv_bin = "$local_uv_root\bin"
 
 $TOOL_VERSION = Invoke-Expression -Command "python -c ""import os;import sys;content={};f=open(r'$($current_dir)/version.py');exec(f.read(),content);f.close();print(content['__version__'])"""
 
@@ -44,11 +46,8 @@ function Install-Uv() {
         return
     }
     Write-Host ">>> Installing uv ..."
-    $env:UV_UNMANAGED_INSTALL = "$repo_root\.uv"
+    $env:UV_UNMANAGED_INSTALL = $local_uv_root
     Invoke-WebRequest -Uri "https://astral.sh/uv/install.ps1" -UseBasicParsing | Invoke-Expression
-    if (-not (Get-Command "uv" -ErrorAction SilentlyContinue)) {
-        $env:PATH = "$repo_root\.uv\bin;$env:PATH"
-    }
 }
 
 function CreateDockerPrivate {
@@ -112,6 +111,13 @@ function CreatePackageWithDocker {
 
 function Change-Cwd() {
     Set-Location -Path $repo_root
+    if (Test-Path -PathType Container -Path $local_uv_path) {
+        # Keep local uv first in PATH, but avoid duplicates.
+        $pathParts = @($env:PATH -split ';' | Where-Object {
+            $_ -and ($_ -ne $local_uv_bin)
+        })
+        $env:PATH = @($local_uv_bin) + $pathParts -join ';'
+    }
 }
 
 function Restore-Cwd() {

--- a/start.ps1
+++ b/start.ps1
@@ -9,6 +9,7 @@ $repo_root_rel = Split-Path -Path $MyInvocation.MyCommand.Definition -Parent
 $repo_root = (Get-Item $repo_root_rel).FullName
 $local_uv_root = "$repo_root\.uv"
 $local_uv_bin = "$local_uv_root\bin"
+$local_uv_path = "$local_uv_bin\uv.exe"
 
 $TOOL_VERSION = Invoke-Expression -Command "python -c ""import os;import sys;content={};f=open(r'$($current_dir)/version.py');exec(f.read(),content);f.close();print(content['__version__'])"""
 
@@ -41,6 +42,10 @@ function Exit-WithCode($exitcode) {
 
 function Install-Uv() {
     Write-Host ">>> Checking for uv ..."
+    if (Test-Path -PathType Container -Path $local_uv_path) {
+        Write-Host ">>> local uv already installed: $(& $local_uv_path --version 2> $null)"
+        return
+    }
     if (Get-Command "uv" -ErrorAction SilentlyContinue) {
         Write-Host ">>> uv already installed: $(uv --version)"
         return

--- a/start.ps1
+++ b/start.ps1
@@ -8,8 +8,7 @@ $current_dir = Get-Location
 $repo_root_rel = Split-Path -Path $MyInvocation.MyCommand.Definition -Parent
 $repo_root = (Get-Item $repo_root_rel).FullName
 $local_uv_root = "$repo_root\.uv"
-$local_uv_bin = "$local_uv_root\bin"
-$local_uv_path = "$local_uv_bin\uv.exe"
+$local_uv_path = "$local_uv_root\uv.exe"
 
 $TOOL_VERSION = Invoke-Expression -Command "python -c ""import os;import sys;content={};f=open(r'$($current_dir)/version.py');exec(f.read(),content);f.close();print(content['__version__'])"""
 
@@ -51,7 +50,7 @@ function Install-Uv() {
         return
     }
     Write-Host ">>> Installing uv ..."
-    $env:UV_UNMANAGED_INSTALL = $local_uv_root
+    $env:UV_INSTALL_DIR = $local_uv_root
     Invoke-WebRequest -Uri "https://astral.sh/uv/install.ps1" -UseBasicParsing | Invoke-Expression
 }
 
@@ -119,9 +118,9 @@ function Change-Cwd() {
     if (Test-Path -PathType Container -Path $local_uv_path) {
         # Keep local uv first in PATH, but avoid duplicates.
         $pathParts = @($env:PATH -split ';' | Where-Object {
-            $_ -and ($_ -ne $local_uv_bin)
+            $_ -and ($_ -ne $local_uv_root)
         })
-        $env:PATH = @($local_uv_bin) + $pathParts -join ';'
+        $env:PATH = @($local_uv_root) + $pathParts -join ';'
     }
 }
 

--- a/start.ps1
+++ b/start.ps1
@@ -51,6 +51,7 @@ function Install-Uv() {
     }
     Write-Host ">>> Installing uv ..."
     $env:UV_INSTALL_DIR = $local_uv_root
+    $env:UV_NO_MODIFY_PATH = "1"
     Invoke-WebRequest -Uri "https://astral.sh/uv/install.ps1" -UseBasicParsing | Invoke-Expression
 }
 

--- a/start.ps1
+++ b/start.ps1
@@ -159,18 +159,18 @@ function main {
     } elseif ($FunctionName -eq "listen") {
         Change-Cwd
         set_env
-        & "$repo_root\.venv\Scripts\python.exe" "$($repo_root)\service" @arguments
+        & uv run python "$($repo_root)\service" @arguments
     } elseif ($FunctionName -eq "setenv") {
         Change-Cwd
         set_env
     } elseif ($FunctionName -eq "create") {
         Change-Cwd
         set_env
-        & "$repo_root\.venv\Scripts\python.exe" "$($repo_root)\dependencies" create @arguments
+        & uv run python "$($repo_root)\dependencies" create @arguments
     } elseif ($FunctionName -eq "listbundles") {
         Change-Cwd
         set_env
-        & "$repo_root\.venv\Scripts\python.exe" "$($repo_root)\dependencies" list-bundles @arguments
+        & uv run python "$($repo_root)\dependencies" list-bundles @arguments
     } elseif ($FunctionName -eq "dockercreate") {
         Change-Cwd
         set_env

--- a/start.sh
+++ b/start.sh
@@ -113,19 +113,19 @@ set_env () {
 
 listen () {
   pushd "$repo_root" > /dev/null || return > /dev/null
-  "$repo_root/.venv/bin/python" "$repo_root/service" "$@"
+  uv run python "$repo_root/service" "$@"
 }
 
 create_bundle() {
   pushd "$repo_root" > /dev/null || return > /dev/null
   set_env
-  "$repo_root/.venv/bin/python" "$repo_root/dependencies" create "$@"
+  uv run python "$repo_root/dependencies" create "$@"
 }
 
 list_bundles() {
   pushd "$repo_root" > /dev/null || return > /dev/null
   set_env
-  "$repo_root/.venv/bin/python" "$repo_root/dependencies" list-bundles "$@"
+  uv run python "$repo_root/dependencies" list-bundles "$@"
 }
 
 create_docker_image_private() {

--- a/start.sh
+++ b/start.sh
@@ -48,6 +48,9 @@ realpath () {
 }
 
 repo_root=$(dirname "$(realpath ${BASH_SOURCE[0]})")
+local_uv_root="$repo_root/.uv"
+local_uv_bin="$local_uv_root/bin"
+local_uv_path="$local_uv_bin/uv"
 version_command="import os;exec(open(os.path.join('$repo_root', 'version.py')).read());print(__version__);"
 tool_version="$(python <<< ${version_command})"
 
@@ -62,15 +65,43 @@ tool_version="$(python <<< ${version_command})"
 #   None
 ###############################################################################
 install_uv () {
+  if [ -d $local_uv_path ]; then
+    echo -e "${BIGreen}>>>${RST} uv already installed: $($local_uv_path --version)"
+    return 0
+  fi
   if command -v uv >/dev/null 2>&1; then
     echo -e "${BIGreen}>>>${RST} uv already installed: $(uv --version)"
     return 0
   fi
   echo -e "${BIGreen}>>>${RST} Installing uv ..."
-  export UV_UNMANAGED_INSTALL="$repo_root/.uv"
+  export UV_UNMANAGED_INSTALL=$local_uv_root
   command -v curl >/dev/null 2>&1 || { echo -e "${BIRed}!!!${RST}${BIYellow} Missing ${RST}${BIBlue}curl${BIYellow} command.${RST}"; return 1; }
   curl -LsSf https://astral.sh/uv/install.sh | sh
-  export PATH="$repo_root/.uv/bin:$PATH"
+}
+
+set_uv_path () {
+  if [ -d "$local_uv_bin" ]; then
+    # Keep local uv first in PATH, but avoid duplicates.
+    normalized_local_uv_bin="${local_uv_bin%/}"
+    deduped_path=""
+    IFS=':' read -r -a path_parts <<< "$PATH"
+    for path_part in "${path_parts[@]}"; do
+      [ -z "$path_part" ] && continue
+      normalized_part="${path_part%/}"
+      [ "$normalized_part" = "$normalized_local_uv_bin" ] && continue
+      if [ -z "$deduped_path" ]; then
+        deduped_path="$path_part"
+      else
+        deduped_path="$deduped_path:$path_part"
+      fi
+    done
+
+    if [ -z "$deduped_path" ]; then
+      export PATH="$local_uv_bin"
+    else
+      export PATH="$local_uv_bin:$deduped_path"
+    fi
+  fi
 }
 
 ##############################################################################
@@ -217,6 +248,7 @@ main() {
   esac
 
   install_uv || return_code=$?
+  set_uv_path
   if [ $return_code != 0 ]; then
     echo -e "${BIRed}!!!${RST} uv installation failed"
     exit $return_code

--- a/start.sh
+++ b/start.sh
@@ -49,8 +49,7 @@ realpath () {
 
 repo_root=$(dirname "$(realpath ${BASH_SOURCE[0]})")
 local_uv_root="$repo_root/.uv"
-local_uv_bin="$local_uv_root/bin"
-local_uv_path="$local_uv_bin/uv"
+local_uv_path="$local_uv_root/uv"
 version_command="import os;exec(open(os.path.join('$repo_root', 'version.py')).read());print(__version__);"
 tool_version="$(python <<< ${version_command})"
 
@@ -65,30 +64,32 @@ tool_version="$(python <<< ${version_command})"
 #   None
 ###############################################################################
 install_uv () {
-  if [ -d $local_uv_path ]; then
-    echo -e "${BIGreen}>>>${RST} uv already installed: $($local_uv_path --version)"
+  if command -v $local_uv_path >/dev/null 2>&1; then
+    echo -e "${BIGreen}>>>${RST} local uv already installed: $($local_uv_path --version)"
+    echo -e "${BIGreen}>>>${RST} - $local_uv_path"
     return 0
   fi
   if command -v uv >/dev/null 2>&1; then
     echo -e "${BIGreen}>>>${RST} uv already installed: $(uv --version)"
+    echo -e "${BIGreen}>>>${RST} - $(which uv)"
     return 0
   fi
   echo -e "${BIGreen}>>>${RST} Installing uv ..."
-  export UV_UNMANAGED_INSTALL=$local_uv_root
+  export UV_INSTALL_DIR=$local_uv_root
   command -v curl >/dev/null 2>&1 || { echo -e "${BIRed}!!!${RST}${BIYellow} Missing ${RST}${BIBlue}curl${BIYellow} command.${RST}"; return 1; }
   curl -LsSf https://astral.sh/uv/install.sh | sh
 }
 
 set_uv_path () {
-  if [ -d "$local_uv_bin" ]; then
+  if [ -d "$local_uv_root" ]; then
     # Keep local uv first in PATH, but avoid duplicates.
-    normalized_local_uv_bin="${local_uv_bin%/}"
+    normalized_local_uv_root="${local_uv_root%/}"
     deduped_path=""
     IFS=':' read -r -a path_parts <<< "$PATH"
     for path_part in "${path_parts[@]}"; do
       [ -z "$path_part" ] && continue
       normalized_part="${path_part%/}"
-      [ "$normalized_part" = "$normalized_local_uv_bin" ] && continue
+      [ "$normalized_part" = "$normalized_local_uv_root" ] && continue
       if [ -z "$deduped_path" ]; then
         deduped_path="$path_part"
       else
@@ -97,9 +98,9 @@ set_uv_path () {
     done
 
     if [ -z "$deduped_path" ]; then
-      export PATH="$local_uv_bin"
+      export PATH="$local_uv_root"
     else
-      export PATH="$local_uv_bin:$deduped_path"
+      export PATH="$local_uv_root:$deduped_path"
     fi
   fi
 }
@@ -237,10 +238,6 @@ main() {
   function_name="$(echo "$1" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z]*//g')"
 
   case $function_name in
-    "install")
-      install || return_code=$?
-      exit $return_code
-      ;;
     "setenv")
       set_env || return_code=$?
       exit $return_code
@@ -255,6 +252,10 @@ main() {
   fi
 
   case $function_name in
+    "install")
+      install || return_code=$?
+      exit $return_code
+      ;;
     "listen")
       listen "${@:2}" || return_code=$?
       exit $return_code

--- a/start.sh
+++ b/start.sh
@@ -76,6 +76,7 @@ install_uv () {
   fi
   echo -e "${BIGreen}>>>${RST} Installing uv ..."
   export UV_INSTALL_DIR=$local_uv_root
+  export UV_NO_MODIFY_PATH="1"
   command -v curl >/dev/null 2>&1 || { echo -e "${BIRed}!!!${RST}${BIYellow} Missing ${RST}${BIBlue}curl${BIYellow} command.${RST}"; return 1; }
   curl -LsSf https://astral.sh/uv/install.sh | sh
 }

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "ayon-dependencies-tool"
-version = "1.2.1.dev0"
+version = "1.3.2.dev0"
 source = { virtual = "." }
 dependencies = [
     { name = "appdirs" },


### PR DESCRIPTION
## Changelog Description
Dependencies tool uses correct python version for dependency package creation and fix local uv installation.

## Additional review information
Use `UV_INSTALL_DIR` instead of `UV_UNMANAGED_INSTALL`. Local uv is always used if is available. Use `uv run python` instead of `venv/bin/python`. Don't use subdir `/bin` for uv binary. Fix various bugs in core logic. Make sure that python from venv is used for building packages in custom resolver, in case a package needs to run `setup.py` it needs access to python, because venv's python is not in PATH the python from dependencies tool is used which can be 3.14.x -> leading to crash.

Also fixed runtime dependency resolving -> runtime dependencies in created package did contain runtime dependencies from AYON launcher.

## Testing notes:
1. Dependency packages can be created.

Based on https://github.com/ynput/ayon-dependencies-tool/pull/48 .